### PR TITLE
Add memory service v2 specs

### DIFF
--- a/.codex/specs/memory_service_v2/design.md
+++ b/.codex/specs/memory_service_v2/design.md
@@ -1,0 +1,44 @@
+# Memory Service v2 Design
+
+This document describes the high-level architecture for the v2 memory service, including data models and API interactions.
+
+## Architecture Overview
+
+The service is composed of two FastAPI applications:
+
+1. **External API** – exposed to other services and clients.
+2. **Internal API** – used by crew agents and internal processes.
+
+Both applications share the same database layer and validation logic. A common module should provide request schemas and response formatting to ensure consistency.
+
+### Database
+
+A single PostgreSQL database (Supabase in production) stores all memory data. Core tables include:
+
+- `memory_entities` – stores entities with fields `id`, `actor_id`, `entity_type`, `content`, `created_at`, and `deleted`.
+- `memory_observations` – stores observations tied to an entity with metadata JSONB.
+- `object_schemas` – defines validation schemas for specific entity types.
+
+### Data Access Layer
+
+The service uses SQLAlchemy models with pydantic schemas for validation. Queries should respect the four-realm hierarchy by joining related memories based on `actor_id` and realm type.
+
+### API Interaction
+
+All endpoints return JSON responses with `success` or `error` fields. Examples:
+
+- **Create Entity** – returns `{ "id": <uuid>, "status": "created" }`.
+- **Search** – returns a list of entities and observations sorted by realm priority.
+
+Batch operations accept arrays of objects and provide per-object status messages.
+
+## Authentication Flow
+
+External requests pass an API token which is verified against a table of active tokens. Internal requests include an `X-Internal-Secret` header which must match the configured secret. The middleware layer handles authentication and returns `401` on failure.
+
+## Deployment Considerations
+
+- The service should ship with Dockerfiles for both internal and external deployments.
+- Health endpoints (`/health`) expose basic status for Railway checks.
+- Environment variables specify database connection strings and shared secrets.
+

--- a/.codex/specs/memory_service_v2/requirements.md
+++ b/.codex/specs/memory_service_v2/requirements.md
@@ -1,0 +1,46 @@
+# Memory Service v2 Requirements
+
+This document outlines the functional requirements for the next version of the SparkJAR memory service.
+
+## Four-Realm Memory Hierarchy
+
+The system must organize memories across four realms:
+
+1. **Client** – highest priority overrides for specific clients.
+2. **Synth Class** – shared knowledge for a class of synths.
+3. **Synth** – memories unique to a single synth actor.
+4. **Skill Module** – reusable knowledge modules that any synth can adopt.
+
+Queries must resolve memories by priority in the order above, ensuring that client overrides take precedence over class and individual synth memories.
+
+## Entity Validation
+
+All API inputs must be validated before persistence:
+
+- **Entities** require a valid `actor_id`, `entity_type`, and `content` field.
+- **Observations** require an existing entity reference and structured metadata.
+- Incoming requests with invalid types or missing fields must return `400` errors with descriptive messages.
+
+## API Endpoints
+
+The service exposes both internal and external APIs. Key endpoints include:
+
+- `POST /entities` – upsert memory entities.
+- `POST /observations` – attach observations to an entity.
+- `GET /entities/{id}` – fetch a single entity including observations.
+- `GET /search` – query memories across realms.
+- `DELETE /entities/{id}` – soft delete an entity.
+
+Both interfaces should maintain consistent request/response formats.
+
+## Authentication
+
+- External requests require an API token provided via the `Authorization` header.
+- Internal service-to-service calls use a shared secret configured via environment variables.
+- Unauthorized requests must receive a `401` response.
+
+## Performance Targets
+
+- Individual queries should return within **100ms** when using a remote database.
+- Batch upserts must handle at least **50** entities per request.
+

--- a/.codex/specs/memory_service_v2/tasks.md
+++ b/.codex/specs/memory_service_v2/tasks.md
@@ -1,0 +1,20 @@
+# Codex Implementation Tasks for Memory Service v2
+
+This file outlines the high level tasks for Codex agents to bring the new memory service specification to life.
+
+1. **Unify Internal and External APIs**
+   - Extract shared request/response schemas into a common module.
+   - Ensure both FastAPI apps import the same validation logic.
+2. **Refactor Tests**
+   - Update existing unit tests to cover the new four-realm hierarchy logic.
+   - Add integration tests for entity/observation validation and authentication.
+3. **Database Migration**
+   - Create migration scripts for any new tables or fields required by v2.
+   - Verify backward compatibility with existing data.
+4. **Deployment Updates**
+   - Review Dockerfiles and Railway configs to support the combined API modules.
+   - Add environment variables for internal secrets and API tokens.
+5. **Documentation**
+   - Update API reference docs to match v2 endpoints and response formats.
+   - Provide usage examples demonstrating cross-realm queries.
+


### PR DESCRIPTION
## Summary
- outline functional requirements for memory service v2
- describe design architecture for memory service v2
- list tasks for Codex agents to implement the spec

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a64512a8c832dadebd21377c390de