### PR TITLE
Add trimmed env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# Sparkjar Memory Service Environment Variables
+# Copy to .env and adjust values as needed.
+
+# Database
+DATABASE_URL=postgresql://test:test@localhost:5432/test_db
+DATABASE_URL_DIRECT=postgresql://test:test@localhost:5432/test_db
+SUPABASE_URL=
+SUPABASE_SERVICE_KEY=
+
+# Authentication
+SECRET_KEY=
+API_SECRET_KEY=
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+
+# Embeddings (OpenAI)
+EMBEDDING_PROVIDER=openai
+OPENAI_API_KEY=
+OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+OPENAI_EMBEDDING_DIMENSION=1536
+
+# Service ports
+INTERNAL_API_HOST=::
+INTERNAL_API_PORT=8001
+EXTERNAL_API_HOST=0.0.0.0
+EXTERNAL_API_PORT=8443
+PORT=8001
+
+# Other settings
+GPT_MODEL=gpt-4.1-nano
+

--- a/README.md
+++ b/README.md
@@ -90,9 +90,11 @@ API_SECRET_KEY=your-secret-key
 OPENAI_API_KEY=your-openai-key
 
 # Embeddings
-EMBEDDING_PROVIDER=custom
-EMBEDDINGS_API_URL=http://embeddings.railway.internal:8000
+EMBEDDING_PROVIDER=openai
+OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 ```
+
+See `.env.example` for the complete set of variables and default values.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- prune unnecessary environment variables from `.env.example`
- reference OpenAI embeddings in README snippet

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688a9a3c6d90832dbd2bf7af51827e67