### PR TITLE
Add schemas endpoint

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -879,6 +879,28 @@ Every entity MUST have at least one relationship. Common patterns:
 }
 ```
 
+### 15. List Object Schemas
+
+Retrieve schemas stored in the `object_schemas` table.
+
+**Endpoint:** `GET /schemas`
+
+**Query Parameters:**
+- `object_type` (optional) – filter results by object type.
+
+**Response:**
+```json
+[
+  {
+    "id": 1,
+    "name": "procedure_metadata",
+    "object_type": "memory_entity_metadata",
+    "schema": {"required": ["version"]},
+    "created_at": "2024-01-01T00:00:00Z"
+  }
+]
+```
+
 ## Error Responses
 
 All endpoints return standard error responses:


### PR DESCRIPTION
## Summary
- implement `/schemas` endpoint for internal API
- document object schema listing
- test schema endpoint

## Testing
- `ruff check internal_api.py tests/test_api_endpoints.py`
- `pytest tests/test_api_endpoints.py::TestInternalAPI::test_list_schemas -vv`


------
https://chatgpt.com/codex/tasks/task_e_688aa467429c832db40e0ca3d93b5d17