### PR TITLE
Add skill module metadata schema and docs

### DIFF
--- a/docs/MEMORY_SYSTEM_MASTER_GUIDE.md
+++ b/docs/MEMORY_SYSTEM_MASTER_GUIDE.md
@@ -324,6 +324,24 @@ Creates entity with relationships and observations in one transaction:
 }
 ```
 
+Example using `skill_module_metadata`:
+
+```json
+{
+  "actor_type": "skill_module",
+  "actor_id": "image_tools",
+  "entity": {
+    "name": "background_removal",
+    "type": "integration",
+    "metadata": {
+      "module_name": "image_tools",
+      "instruction_set": "remove_background",
+      "version": "1.0"
+    }
+  }
+}
+```
+
 #### 2. Search Across Realms
 `POST /memory/search/realms`
 

--- a/scripts/seed_memory_schemas.py
+++ b/scripts/seed_memory_schemas.py
@@ -281,6 +281,23 @@ async def seed_memory_schemas():
                 "required": ["agent_type"],
                 "additionalProperties": True
             }
+        },
+        {
+            "name": "skill_module_metadata",
+            "object_type": "memory_entity_metadata",
+            "description": "Schema for skill module metadata",
+            "schema": {
+                "$id": "skill_module_metadata",
+                "type": "object",
+                "title": "Skill Module Metadata Schema",
+                "properties": {
+                    "module_name": {"type": "string"},
+                    "instruction_set": {"type": "string"},
+                    "version": {"type": "string"}
+                },
+                "required": ["module_name", "instruction_set"],
+                "additionalProperties": True
+            }
         }
     ]
     


### PR DESCRIPTION
## Summary
- add `skill_module_metadata` schema in seeding script
- document usage of `skill_module_metadata` in the master guide

## Testing
- `ruff check .` *(fails: 855 errors)*
- `pytest -q` *(fails to collect tests due to ImportError: cannot import name 'settings')*

------
https://chatgpt.com/codex/tasks/task_e_688aa4520e18832d8cee7e5ef60faa84