### PR TITLE
Add summarizer to ingestion flow

### DIFF
--- a/services/memory_manager.py
+++ b/services/memory_manager.py
@@ -18,6 +18,7 @@ from .actor_validator import ActorValidator, InvalidActorError
 from sparkjar_crew.shared.database.models import MemoryEntities, MemoryRelations, ObjectSchemas, MemoryObservations
 from sparkjar_crew.shared.schemas.memory_schemas import EntityCreate, RelationCreate, ObservationAdd
 from .embeddings import EmbeddingService
+from .summarizer import apply_draft_summaries
 import jsonschema
 from jsonschema import validate, ValidationError
 
@@ -389,7 +390,9 @@ class MemoryManager:
                 
                 # Create new observations
                 for obs in entity_data.observations:
-                    obs_value = obs.value if isinstance(obs.value, dict) else {"value": obs.value}
+                    obs_dict = obs.model_dump()
+                    apply_draft_summaries([obs_dict])
+                    obs_value = obs_dict["value"] if isinstance(obs_dict["value"], dict) else {"value": obs_dict["value"]}
                     for key, value in obs_value.items():
                         if isinstance(value, datetime):
                             obs_value[key] = value.isoformat()
@@ -414,6 +417,7 @@ class MemoryManager:
                 
                 for obs in entity_data.observations:
                     obs_dict = obs.dict()
+                    apply_draft_summaries([obs_dict])
                     all_observations.append(obs_dict)
                 
                 text_content = self.embedding_service.prepare_entity_text_from_data(
@@ -431,6 +435,7 @@ class MemoryManager:
             
             # Create new entity
             observations = [obs.model_dump() for obs in entity_data.observations]
+            apply_draft_summaries(observations)
             
             # Validate observations against schemas
             validated_observations = self._validate_observations(observations, entity_data.entityType)
@@ -604,7 +609,7 @@ class MemoryManager:
                 obs_dict = obs.dict()
                 # Check for duplicate observations
                 if not any(
-                    existing.get('type') == obs_dict.get('type') and 
+                    existing.get('type') == obs_dict.get('type') and
                     existing.get('value') == obs_dict.get('value')
                     for existing in existing_obs_list
                 ):
@@ -612,6 +617,7 @@ class MemoryManager:
             
             # Validate and create new observations
             if new_obs:
+                apply_draft_summaries(new_obs)
                 validated_new_obs = self._validate_observations(new_obs, entity.entity_type)
                 for obs in validated_new_obs:
                     # Create new observation record

--- a/services/summarizer.py
+++ b/services/summarizer.py
@@ -1,0 +1,14 @@
+from typing import List
+
+def summarize_to_five_words(text: str) -> str:
+    """Return the first five words of the given text."""
+    words = text.strip().split()
+    return " ".join(words[:5])
+
+def apply_draft_summaries(observations: List[dict]) -> None:
+    """Add a 'draft' key with a five-word summary for textual values."""
+    for obs in observations:
+        value = obs.get("value")
+        if isinstance(value, str):
+            obs["draft"] = summarize_to_five_words(value)
+


### PR DESCRIPTION
## Summary
- create a small helper to draft five-word summaries
- generate draft summaries before entity observation validation and embeddings

## Testing
- `ruff check .` *(fails: 816 errors)*
- `pytest -v` *(fails to collect tests due to ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_688afb6db0dc832da6f93855a3fec733