### PR TITLE
Add CoD ingestion test with zero-vector embeddings

### DIFF
--- a/tests/mock_services.py
+++ b/tests/mock_services.py
@@ -1,8 +1,34 @@
+import os
+
+
 class MockEmbeddingService:
-    """Simple embedding service mock returning fixed vectors."""
+    """Simple embedding service mock returning zero vectors."""
+
+    def __init__(self, dimension: int | None = None) -> None:
+        self.dimension = dimension or int(os.getenv("EMBEDDING_DIMENSION", "768"))
 
     async def generate_embedding(self, text: str):
-        return [0.0] * 768
+        return [0.0] * self.dimension
 
     async def generate_embeddings_batch(self, texts):
-        return [[0.0] * 768 for _ in texts]
+        return [[0.0] * self.dimension for _ in texts]
+
+    def prepare_entity_text_from_data(
+        self,
+        entity_name: str,
+        entity_type: str,
+        observations: list[dict],
+    ) -> str:
+        text_parts = [f"Entity: {entity_name}", f"Type: {entity_type}"]
+        for obs in observations:
+            if isinstance(obs, dict):
+                obs_type = obs.get("type", "general")
+                obs_value = obs.get("value", "")
+                obs_source = obs.get("source", "")
+                text_parts.append(f"{obs_type}: {obs_value}")
+                if obs_source and obs_source != "api":
+                    text_parts.append(f"Source: {obs_source}")
+                if "context" in obs and obs["context"]:
+                    for key, value in obs["context"].items():
+                        text_parts.append(f"{key}: {value}")
+        return " | ".join(text_parts)

--- a/tests/test_cod_flow.py
+++ b/tests/test_cod_flow.py
@@ -1,0 +1,55 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
+
+from sparkjar_crew.shared.database.models import Base
+from sparkjar_shared.schemas.memory_schemas import EntityCreate, Observation
+from services.memory_manager import MemoryManager
+import services.memory_manager as mm
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def memory_manager(db_session, mock_embedding_service):
+    return MemoryManager(db_session, mock_embedding_service)
+
+
+@pytest.mark.asyncio
+async def test_cod_ingest_and_retrieve(memory_manager, monkeypatch):
+    actor_type = "client"
+    actor_id = str(uuid4())
+    mm.client_id = actor_id
+    monkeypatch.setattr(mm, "uuid4", lambda: str(uuid4()))
+
+    entity = EntityCreate(
+        name="CoD Test",
+        entityType="cod",
+        observations=[Observation(type="fact", value="demo", source="test")],
+    )
+
+    created = await memory_manager.create_entities(
+        actor_type,
+        actor_id,
+        [entity],
+    )
+    assert len(created) == 1
+
+    result = await memory_manager.open_nodes(
+        actor_type,
+        actor_id,
+        ["CoD Test"],
+    )
+    assert len(result) == 1
+    assert result[0]["entity_name"] == "CoD Test"


### PR DESCRIPTION
## Summary
- extend MockEmbeddingService to support configurable dimensions and provide text formatting helper
- add new `test_cod_flow` covering ingestion and retrieval without embeddings or validation

## Testing
- `ruff check tests/mock_services.py tests/conftest.py tests/test_cod_flow.py`
- `pytest -v tests/test_cod_flow.py`
- `pytest -v` *(fails: ImportError: cannot import name 'settings' from 'config')*

------
https://chatgpt.com/codex/tasks/task_e_688afbe3d654832d810c8a84a3adf45d